### PR TITLE
Add singleplayer deck selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,24 @@
       </div>
     </section>
 
+    <section id="view-deckselect" class="view hidden">
+      <header class="view-header">
+        <h2>Seleziona Mazzi</h2>
+        <button id="btn-cancel-deckselect" class="back-button">Annulla</button>
+      </header>
+      <div class="deck-select">
+        <div>
+          <label for="select-deck1">Giocatore 1</label>
+          <select id="select-deck1"></select>
+        </div>
+        <div>
+          <label for="select-deck2">Giocatore 2</label>
+          <select id="select-deck2"></select>
+        </div>
+        <button id="btn-start-match" class="primary">Inizia Partita</button>
+      </div>
+    </section>
+
     <section id="view-game" class="view hidden">
       <header class="view-header">
         <h2>Partita</h2>

--- a/style.css
+++ b/style.css
@@ -145,3 +145,14 @@ body {
 
 /* GAME AREA & SETTINGS */
 .game-area, .settings-content { padding:20px; }
+
+/* DECK SELECTION */
+.deck-select { display:flex; flex-direction:column; gap:16px; align-items:center; padding:20px; }
+.deck-select label { margin-right:8px; }
+.deck-select select { padding:4px; }
+
+/* SIMPLE GAME UI */
+.round-select { display:flex; justify-content:space-around; gap:20px; margin-top:20px; }
+.player-col { flex:1; }
+.hand { list-style:none; padding:0; }
+.hand li { margin-bottom:8px; }


### PR DESCRIPTION
## Summary
- let user pick two decks for singleplayer matches
- implement simple Urban Rivals style combat engine
- style deck selection and basic game UI

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_688a7738254c832dbbefd5ee57225f93