### PR TITLE
Add card selection list for deck editing

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const STORAGE_KEY = 'monsterDecks';
 let decks = [];
 let editingDeck = null;
 let editingIndex = null;
+let selectingSlot = null;
 let cardsData = [];
 let gameState = null;
 
@@ -21,6 +22,7 @@ document.addEventListener('DOMContentLoaded', () => {
   views.select = document.getElementById('view-deckselect');
   views.game = document.getElementById('view-game');
   views.settings = document.getElementById('view-settings');
+  views.cardselect = document.getElementById("view-cardselect");
 
   // buttons
   document.getElementById('btn-singleplayer').addEventListener('click', startSingleplayer);
@@ -36,6 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('btn-back-menu-game').addEventListener('click', () => showView('menu'));
   document.getElementById('btn-back-settings').addEventListener('click', () => showView('menu'));
 
+  document.getElementById('btn-back-cardselect').addEventListener('click', () => openEditor(editingIndex));
   fetch('data/cards.json').then(r => r.json()).then(d => { cardsData = d; });
   loadDecks();
   renderDeckList();
@@ -99,11 +102,26 @@ function openEditor(index) {
 }
 
 function selectCardForSlot(i) {
-  const id = prompt(`Inserisci ID carta per slot ${i+1}`);
-  if (id) {
-    editingDeck[i] = parseInt(id);
-    openEditor(editingIndex);
-  }
+  selectingSlot = i;
+  const list = document.getElementById('cards-list');
+  list.innerHTML = '';
+  cardsData.forEach(card => {
+    const li = document.createElement('li');
+    const img = document.createElement('img');
+    img.src = 'assets/cards/placeholder.png';
+    img.alt = card.nome;
+    const name = document.createElement('span');
+    name.textContent = card.nome;
+    li.appendChild(img);
+    li.appendChild(name);
+    li.title = cardInfo(card);
+    li.addEventListener('click', () => {
+      editingDeck[selectingSlot] = card.id;
+      openEditor(editingIndex);
+    });
+    list.appendChild(li);
+  });
+  showView('cardselect');
 }
 
 function saveDeck() {

--- a/index.html
+++ b/index.html
@@ -63,6 +63,14 @@
       </div>
     </section>
 
+    <section id="view-cardselect" class="view hidden">
+      <header class="view-header">
+        <h2>Scegli Carta</h2>
+        <button id="btn-back-cardselect" class="back-button">Annulla</button>
+      </header>
+      <ul id="cards-list" class="card-list"></ul>
+    </section>
+
     <section id="view-deckselect" class="view hidden">
       <header class="view-header">
         <h2>Seleziona Mazzi</h2>

--- a/style.css
+++ b/style.css
@@ -177,3 +177,10 @@ body {
   object-fit:cover;
   margin-bottom:4px;
 }
+
+/* CARD SELECTION */
+.card-list { list-style:none; display:flex; flex-wrap:wrap; gap:12px; justify-content:center; padding:20px; max-height:60vh; overflow-y:auto; }
+.card-list li { width:80px; background:var(--panel-bg); border:2px solid var(--accent1); cursor:pointer; display:flex; flex-direction:column; align-items:center; margin-bottom:12px; }
+.card-list li img { width:80px; height:120px; object-fit:cover; }
+.card-list li span { font-size:0.8rem; padding:4px; text-align:center; }
+


### PR DESCRIPTION
## Summary
- add a new `view-cardselect` to pick cards from a scrollable list
- add styles for the card selector
- update deck editor logic to use the new list instead of prompts

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_688a8d893498832dbb2f991f2cd37ef9