### PR TITLE
Ensure cards use their own images

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,10 @@ let selectingSlot = null;
 let cardsData = [];
 let gameState = null;
 
+function cardImage(card) {
+  return `assets/cards/${card.immagine || 'placeholder.png'}`;
+}
+
 function cardInfo(card) {
   return `${card.nome} - Potenza ${card.potenza}, Danno ${card.danno}, Abilità: ${card['abilità']}, Clan: ${card.clan}, Bonus: ${card.bonus}, Stelle: ${card.star}`;
 }
@@ -89,7 +93,7 @@ function openEditor(index) {
     if (id) {
       const card = cardsData.find(c => c.id === id);
       const img = document.createElement('img');
-      img.src = 'assets/cards/placeholder.png';
+      img.src = cardImage(card);
       img.alt = card.nome;
       slot.appendChild(img);
       slot.title = cardInfo(card);
@@ -108,7 +112,7 @@ function selectCardForSlot(i) {
   cardsData.forEach(card => {
     const li = document.createElement('li');
     const img = document.createElement('img');
-    img.src = 'assets/cards/placeholder.png';
+    img.src = cardImage(card);
     img.alt = card.nome;
     const name = document.createElement('span');
     name.textContent = card.nome;
@@ -220,7 +224,7 @@ function renderGame() {
         const li = document.createElement('li');
         const btn = document.createElement('button');
         const img = document.createElement('img');
-        img.src = 'assets/cards/placeholder.png';
+        img.src = cardImage(card);
         img.alt = card.nome;
         const label = document.createElement('span');
         label.textContent = `${card.nome} (P:${card.potenza} D:${card.danno})`;


### PR DESCRIPTION
## Summary
- display each card's image using the `immagine` field from `data/cards.json`
- show the correct image when editing decks, picking cards and during matches

## Testing
- `node --check app.js`
- `node -e "const fs=require('fs'); const d=JSON.parse(fs.readFileSync('data/cards.json')); console.log(d.length);"`


------
https://chatgpt.com/codex/tasks/task_e_688b9731607c832d85af5742d2cd04c7